### PR TITLE
SIGKILL is to extreme. It can't be caught so the killed process doesn't ...

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func kill() {
 			p = -p
 		}
 		debugPrint("Killing %d", p)
-		syscall.Kill(p, syscall.SIGKILL)
+		syscall.Kill(p, syscall.SIGTERM)
 	}
 }
 


### PR DESCRIPTION
...have a chance to perform proper shutdown.

Fixes #12.
