### PR TITLE
Make cmd.Start errors fatal.

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,8 @@ func run(ui ui) time.Time {
 		io.WriteString(out, strings.Join(flag.Args(), " ")+"\n")
 		start := time.Now()
 		if err := cmd.Start(); err != nil {
-			io.WriteString(out, err.Error()+"\n")
+			io.WriteString(out, "fatal: "+err.Error()+"\n")
+			os.Exit(1)
 		}
 		if s := wait(start, cmd); s != 0 {
 			io.WriteString(out, "exit status "+strconv.Itoa(s)+"\n")


### PR DESCRIPTION
They indicate that we can't run the command.
For example, if it's not found or not executable.

Fixes #17.